### PR TITLE
Update to work with Zabbix 7.x Auth Headers instead of 'auth' in json payload

### DIFF
--- a/openwebui_tool.py
+++ b/openwebui_tool.py
@@ -39,7 +39,7 @@ class Tools:
         self.headers = {'Content-Type': 'application/json'}
         self.citation = True
         
-    # Auth headers    
+    # Auth headers
     def _auth_headers(self):
         headers = self.headers.copy()
         if self.valves.zabbix_api_token:

--- a/openwebui_tool.py
+++ b/openwebui_tool.py
@@ -38,11 +38,13 @@ class Tools:
         self.valves = self.Valves()
         self.headers = {'Content-Type': 'application/json'}
         self.citation = True
+        
+    # Auth headers    
     def _auth_headers(self):
-    headers = self.headers.copy()
-    if self.valves.zabbix_api_token:
-        headers["Authorization"] = f"Bearer {self.valves.zabbix_api_token}"
-    return headers
+        headers = self.headers.copy()
+        if self.valves.zabbix_api_token:
+            headers["Authorization"] = f"Bearer {self.valves.zabbix_api_token}"
+        return headers
 
     # Configuration class
     class Valves(BaseModel):

--- a/openwebui_tool.py
+++ b/openwebui_tool.py
@@ -42,8 +42,12 @@ class Tools:
     # Auth headers
     def _auth_headers(self):
         headers = self.headers.copy()
-        if self.valves.zabbix_api_token:
-            headers["Authorization"] = f"Bearer {self.valves.zabbix_api_token}"
+        if not self.valves.zabbix_api_token:
+            raise ValueError(
+                "Zabbix API token is not configured. "
+                "Please set 'zabbix_api_token' in the tool configuration before making API calls."
+            )
+        headers["Authorization"] = f"Bearer {self.valves.zabbix_api_token}"
         return headers
 
     # Configuration class

--- a/openwebui_tool.py
+++ b/openwebui_tool.py
@@ -36,8 +36,13 @@ def validate_prompt(prompt, max_length):
 class Tools:
     def __init__(self):
         self.valves = self.Valves()
-        self.headers = {'Content-Type': 'application/json-rpc'}
+        self.headers = {'Content-Type': 'application/json'}
         self.citation = True
+    def _auth_headers(self):
+    headers = self.headers.copy()
+    if self.valves.zabbix_api_token:
+        headers["Authorization"] = f"Bearer {self.valves.zabbix_api_token}"
+    return headers
 
     # Configuration class
     class Valves(BaseModel):
@@ -70,9 +75,8 @@ class Tools:
                 'output': ['host', 'status'],
             },
             'id': 1,
-            'auth': self.valves.zabbix_api_token
         }
-        response, error = api_request(self.valves.zabbix_api_url, self.headers, body)
+        response, error = api_request(self.valves.zabbix_api_url, self._auth_headers(), body)
 
         if error:
             status = 'Error retrieving host list.'
@@ -102,9 +106,8 @@ class Tools:
                 'output': ['name'],
             },
             'id': 1,
-            'auth': self.valves.zabbix_api_token
         }
-        response, error = api_request(self.valves.zabbix_api_url, self.headers, body)
+        response, error = api_request(self.valves.zabbix_api_url, self._auth_headers(), body)
 
         if error:
             status = 'Error retrieving problem list.'
@@ -137,9 +140,8 @@ class Tools:
                 'output': ['name'],
             },
             'id': 1,
-            'auth': self.valves.zabbix_api_token
         }
-        response, error = api_request(self.valves.zabbix_api_url, self.headers, body)
+        response, error = api_request(self.valves.zabbix_api_url, self._auth_headers(), body)
 
         if error:
             status = 'Error retrieving item list.'
@@ -176,9 +178,8 @@ class Tools:
                 'output': ['name', 'lastvalue', 'units'],
             },
             'id': 1,
-            'auth': self.valves.zabbix_api_token
         }
-        response, error = api_request(self.valves.zabbix_api_url, self.headers, body)
+        response, error = api_request(self.valves.zabbix_api_url, self._auth_headers(), body)
 
         if error:
             status = 'Error retrieving item value.'


### PR DESCRIPTION
I fixed this and tested. Existing code will not work with Zabbix 7.4.5 (possibly older in the 7.x but this is my version) due to a change in how Zabbix authorizes API tokens. This now passes the bearer token in the header instead of in the json payload. Hope this helps 😁 